### PR TITLE
Update README.md. Add BITS Pilani Hyderabad Campus

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ This repository contains the list of FOSS and open source related clubs at the I
 |[Indian institute of technology, Kharagpur](http://iitkgp.ac.in/)|[Kharagpur open source society](http://kossiitkgp.in/)|[KWOC](http://kwoc.kossiitkgp.in/)|
 |[LNMIIT - Jaipur](http://iitkgp.ac.in/)||[WikiToLearn, India](https://www.facebook.com/events/239194046515064/)|
 |[Mukesh Patel School of Technology Management & Engineering](http://engineering.nmims.edu/)|[MPSTME GLUG](https://www.facebook.com/mpstme.glug/)| Meetups/Trainings conducted : <ul><li>CS101 Programming with Python</li><li>Python for faculty</li><li>Linux Install Fest</li><li>Grand Theft Ruby</li><li>Advanced C++ Workshop</li><li>Software Freedom Day</li></ul> Internal Events <ul><li>OS concepts with Linux</li><li>Bash : Noob to Power User</li></ul>|
+|[BITS Pilani Hyderabad Campus](http://www.bits-pilani.ac.in/hyderabad/)|[Foss@Bphc](https://fossbphc.github.io/)| Foss Winter Of Code |


### PR DESCRIPTION
Adds Foss@Bphc, the FOSS club of Birla Institute of Technology and Science, Pilani, Hyderabad Campus.